### PR TITLE
simple trick to avoid recreating t-batches for each epoch, but no great speedup, gpu mem is still bottleneck.

### DIFF
--- a/evaluate_interaction_prediction.py
+++ b/evaluate_interaction_prediction.py
@@ -27,7 +27,7 @@ args.datapath = "data/%s.csv" % args.network
 if args.train_proportion > 0.8:
     sys.exit('Training sequence proportion cannot be greater than 0.8.')
 if args.network == "mooc":
-    print "No interaction prediction for %s" % args.network
+    print("No interaction prediction for %s" % args.network)
     sys.exit(0)
     
 # SET GPU
@@ -43,7 +43,7 @@ if os.path.exists(output_fname):
     for l in f:
         l = l.strip()
         if search_string in l:
-            print "Output file already has results of epoch %d" % args.epoch
+            print("Output file already has results of epoch %d" % args.epoch)
             sys.exit(0)
     f.close()
 
@@ -58,7 +58,7 @@ num_features = len(feature_sequence[0])
 num_users = len(user2id)
 num_items = len(item2id) + 1
 true_labels_ratio = len(y_true)/(sum(y_true)+1)
-print "*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true))
+print("*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true)))
 
 # SET TRAIN, VALIDATION, AND TEST BOUNDARIES
 train_end_idx = validation_start_idx = int(num_interactions * args.train_proportion)
@@ -121,7 +121,7 @@ Please note that since each interaction in validation and test is only seen once
 tbatch_start_time = None
 loss = 0
 # FORWARD PASS
-print "*** Making interaction predictions by forward pass (no t-batching) ***"
+print("*** Making interaction predictions by forward pass (no t-batching) ***")
 with trange(train_end_idx, test_end_idx) as progress_bar:
     for j in progress_bar:
         progress_bar.set_description('%dth interaction for validation and testing' % j)
@@ -218,13 +218,13 @@ performance_dict['test'] = [mrr, rec10]
 fw = open(output_fname, "a")
 metrics = ['Mean Reciprocal Rank', 'Recall@10']
 
-print '\n\n*** Validation performance of epoch %d ***' % args.epoch
+print('\n\n*** Validation performance of epoch %d ***' % args.epoch)
 fw.write('\n\n*** Validation performance of epoch %d ***\n' % args.epoch)
 for i in xrange(len(metrics)):
     print(metrics[i] + ': ' + str(performance_dict['validation'][i]))
     fw.write("Validation: " + metrics[i] + ': ' + str(performance_dict['validation'][i]) + "\n")
     
-print '\n\n*** Test performance of epoch %d ***' % args.epoch
+print('\n\n*** Test performance of epoch %d ***' % args.epoch)
 fw.write('\n\n*** Test performance of epoch %d ***\n' % args.epoch)
 for i in xrange(len(metrics)):
     print(metrics[i] + ': ' + str(performance_dict['test'][i]))

--- a/evaluate_state_change_prediction.py
+++ b/evaluate_state_change_prediction.py
@@ -28,7 +28,7 @@ args.datapath = "data/%s.csv" % args.network
 if args.train_proportion > 0.8:
     sys.exit('Training sequence proportion cannot be greater than 0.8.')
 if args.network == "lastfm":
-    print "No state change prediction for %s" % args.network
+    print("No state change prediction for %s" % args.network)
     sys.exit(0)
     
 # SET GPU
@@ -44,7 +44,7 @@ if os.path.exists(output_fname):
     for l in f:
         l = l.strip()
         if search_string in l:
-            print "Output file already has results of epoch %d" % args.epoch
+            print("Output file already has results of epoch %d" % args.epoch)
             sys.exit(0)
     f.close()
 
@@ -59,7 +59,7 @@ num_features = len(feature_sequence[0])
 num_users = len(user2id)
 num_items = len(item2id) + 1
 true_labels_ratio = len(y_true)/(sum(y_true)+1)
-print "*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true))
+print("*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true)))
         
 # SET TRAIN, VALIDATION, AND TEST BOUNDARIES
 train_end_idx = validation_start_idx = int(num_interactions * args.train_proportion)
@@ -124,7 +124,7 @@ Please note that since each interaction in validation and test is only seen once
 tbatch_start_time = None
 loss = 0
 # FORWARD PASS
-print "*** Making state change predictions by forward pass (no t-batching) ***"
+print("*** Making state change predictions by forward pass (no t-batching) ***")
 with trange(train_end_idx, test_end_idx) as progress_bar:
     for j in progress_bar:
         progress_bar.set_description('%dth interaction for validation and testing' % j)
@@ -218,14 +218,14 @@ performance_dict['test'] = [auc]
 fw = open(output_fname, "a")
 metrics = ['AUC']
 
-print '\n\n*** Validation performance of epoch %d ***' % args.epoch
+print('\n\n*** Validation performance of epoch %d ***' % args.epoch)
 fw.write('\n\n*** Validation performance of epoch %d ***\n' % args.epoch)
 
 for i in xrange(len(metrics)):
     print(metrics[i] + ': ' + str(performance_dict['validation'][i]))
     fw.write("Validation: " + metrics[i] + ': ' + str(performance_dict['validation'][i]) + "\n")
 
-print '\n\n*** Test performance of epoch %d ***' % args.epoch
+print('\n\n*** Test performance of epoch %d ***' % args.epoch)
 fw.write('\n\n*** Test performance of epoch %d ***\n' % args.epoch)
 for i in xrange(len(metrics)):
     print(metrics[i] + ': ' + str(performance_dict['test'][i]))

--- a/get_final_performance_numbers.py
+++ b/get_final_performance_numbers.py
@@ -43,13 +43,13 @@ if "interaction" in fname:
 else:
     metrics = ['AUC']
 
-print '\n\n*** For file: %s ***' % fname
+print('\n\n*** For file: %s ***' % fname)
 best_val_idx = np.argmax(validation_performances[:,1])
-print "Best validation epoch: %d" % best_val_idx
-print '\n\n*** Best validation performance (epoch %d) ***' % best_val_idx
+print("Best validation epoch: %d" % best_val_idx)
+print('\n\n*** Best validation performance (epoch %d) ***' % best_val_idx)
 for i in xrange(len(metrics)):
     print(metrics[i] + ': ' + str(validation_performances[best_val_idx][i+1]))
 
-print '\n\n*** Final model performance on the test set, i.e., in epoch %d ***' % best_val_idx
+print('\n\n*** Final model performance on the test set, i.e., in epoch %d ***' % best_val_idx)
 for i in xrange(len(metrics)):
     print(metrics[i] + ': ' + str(test_performances[best_val_idx][i+1]))

--- a/jodie.py
+++ b/jodie.py
@@ -158,14 +158,6 @@ with trange(args.epochs) as progress_bar1:
                         lib.current_tbatches_user_timediffs = cached_tbatches_user_timediffs[timestamp]
                         lib.current_tbatches_item_timediffs = cached_tbatches_item_timediffs[timestamp]
                         lib.current_tbatches_previous_item = cached_tbatches_previous_item[timestamp]
-                    else:
-                        cached_tbatches[timestamp] = lib.current_tbatches_user
-                        cached_tbatches[timestamp] = lib.current_tbatches_item
-                        cached_tbatches_interactionids[timestamp] = lib.current_tbatches_interactionids
-                        cached_tbatches_feature[timestamp] = lib.current_tbatches_feature
-                        cached_tbatches_user_timediffs[timestamp] = lib.current_tbatches_user_timediffs
-                        cached_tbatches_item_timediffs[timestamp] = lib.current_tbatches_item_timediffs
-                        cached_tbatches_previous_item[timestamp] = lib.current_tbatches_previous_item
 
 
                     with trange(len(lib.current_tbatches_user)) as progress_bar3:
@@ -239,6 +231,14 @@ with trange(args.epochs) as progress_bar1:
                    
                     # REINITIALIZE
                     if is_first_epoch:
+                        cached_tbatches[timestamp] = lib.current_tbatches_user
+                        cached_tbatches[timestamp] = lib.current_tbatches_item
+                        cached_tbatches_interactionids[timestamp] = lib.current_tbatches_interactionids
+                        cached_tbatches_feature[timestamp] = lib.current_tbatches_feature
+                        cached_tbatches_user_timediffs[timestamp] = lib.current_tbatches_user_timediffs
+                        cached_tbatches_item_timediffs[timestamp] = lib.current_tbatches_item_timediffs
+                        cached_tbatches_previous_item[timestamp] = lib.current_tbatches_previous_item
+                        
                         reinitialize_tbatches()
                         tbatch_to_insert = -1
 

--- a/library_data.py
+++ b/library_data.py
@@ -12,7 +12,6 @@ import operator
 import copy
 from collections import defaultdict
 import os, re
-import cPickle
 import argparse
 from sklearn.preprocessing import scale
 
@@ -40,7 +39,7 @@ def load_network(args, time_scaling=True):
     start_timestamp = None
     y_true_labels = []
 
-    print "\n\n**** Loading %s network from file: %s ****" % (network, datapath)
+    print("\n\n**** Loading %s network from file: %s ****" % (network, datapath))
     f = open(datapath,"r")
     f.readline()
     for cnt, l in enumerate(f):
@@ -52,14 +51,14 @@ def load_network(args, time_scaling=True):
             start_timestamp = float(ls[2])
         timestamp_sequence.append(float(ls[2]) - start_timestamp) 
         y_true_labels.append(int(ls[3])) # label = 1 at state change, 0 otherwise
-        feature_sequence.append(map(float,ls[4:]))
+        feature_sequence.append(list(map(float,ls[4:])))
     f.close()
 
     user_sequence = np.array(user_sequence) 
     item_sequence = np.array(item_sequence)
     timestamp_sequence = np.array(timestamp_sequence)
 
-    print "Formating item sequence"
+    print("Formating item sequence")
     nodeid = 0
     item2id = {}
     item_timedifference_sequence = []
@@ -74,7 +73,7 @@ def load_network(args, time_scaling=True):
     num_items = len(item2id)
     item_sequence_id = [item2id[item] for item in item_sequence]
 
-    print "Formating user sequence"
+    print("Formating user sequence")
     nodeid = 0
     user2id = {}
     user_timedifference_sequence = []
@@ -94,11 +93,11 @@ def load_network(args, time_scaling=True):
     user_sequence_id = [user2id[user] for user in user_sequence]
 
     if time_scaling:
-        print "Scaling timestamps"
+        print("Scaling timestamps")
         user_timedifference_sequence = scale(np.array(user_timedifference_sequence) + 1)
         item_timedifference_sequence = scale(np.array(item_timedifference_sequence) + 1)
 
-    print "*** Network loading completed ***\n\n"
+    print("*** Network loading completed ***\n\n")
     return [user2id, user_sequence_id, user_timedifference_sequence, user_previous_itemid_sequence, \
         item2id, item_sequence_id, item_timedifference_sequence, \
         timestamp_sequence, \

--- a/library_models.py
+++ b/library_models.py
@@ -15,11 +15,11 @@ import math, random
 import sys
 from collections import defaultdict
 import os
-import cPickle
 import gpustat
 from itertools import chain
 from tqdm import tqdm, trange, tqdm_notebook, tnrange
 import csv
+import json
 
 PATH = "./"
 
@@ -46,7 +46,7 @@ class JODIE(nn.Module):
     def __init__(self, args, num_features, num_users, num_items):
         super(JODIE,self).__init__()
 
-        print "*** Initializing the JODIE model ***"
+        print("*** Initializing the JODIE model ***")
         self.modelname = args.model
         self.embedding_dim = args.embedding_dim
         self.num_users = num_users
@@ -54,22 +54,22 @@ class JODIE(nn.Module):
         self.user_static_embedding_size = num_users
         self.item_static_embedding_size = num_items
 
-        print "Initializing user and item embeddings"
+        print("Initializing user and item embeddings")
         self.initial_user_embedding = nn.Parameter(torch.Tensor(args.embedding_dim))
         self.initial_item_embedding = nn.Parameter(torch.Tensor(args.embedding_dim))
 
         rnn_input_size_items = rnn_input_size_users = self.embedding_dim + 1 + num_features
 
-        print "Initializing user and item RNNs"
+        print("Initializing user and item RNNs")
         self.item_rnn = nn.RNNCell(rnn_input_size_users, self.embedding_dim)
         self.user_rnn = nn.RNNCell(rnn_input_size_items, self.embedding_dim)
 
-        print "Initializing linear layers"
+        print("Initializing linear layers")
         self.linear_layer1 = nn.Linear(self.embedding_dim, 50)
         self.linear_layer2 = nn.Linear(50, 2)
         self.prediction_layer = nn.Linear(self.user_static_embedding_size + self.item_static_embedding_size + self.embedding_dim * 2, self.item_static_embedding_size + self.embedding_dim)
         self.embedding_layer = NormalLinear(1, self.embedding_dim)
-        print "*** JODIE initialization complete ***\n\n"
+        print("*** JODIE initialization complete ***\n\n")
         
     def forward(self, user_embeddings, item_embeddings, timediffs=None, features=None, select=None):
         if select == 'item_update':
@@ -141,7 +141,7 @@ def calculate_state_prediction_loss(model, tbatch_interactionids, user_embedding
 
 # SAVE TRAINED MODEL TO DISK
 def save_model(model, optimizer, args, epoch, user_embeddings, item_embeddings, train_end_idx, user_embeddings_time_series=None, item_embeddings_time_series=None, path=PATH):
-    print "*** Saving embeddings and model ***"
+    print("*** Saving embeddings and model ***")
     state = {
             'user_embeddings': user_embeddings.data.cpu().numpy(),
             'item_embeddings': item_embeddings.data.cpu().numpy(),
@@ -161,7 +161,7 @@ def save_model(model, optimizer, args, epoch, user_embeddings, item_embeddings, 
 
     filename = os.path.join(directory, "checkpoint.%s.ep%d.tp%.1f.pth.tar" % (args.model, epoch, args.train_proportion))
     torch.save(state, filename)
-    print "*** Saved embeddings and model to file: %s ***\n\n" % filename
+    print("*** Saved embeddings and model to file: %s ***\n\n" % filename)
 
 
 # LOAD PREVIOUSLY TRAINED AND SAVED MODEL
@@ -169,7 +169,7 @@ def load_model(model, optimizer, args, epoch):
     modelname = args.model
     filename = PATH + "saved_models/%s/checkpoint.%s.ep%d.tp%.1f.pth.tar" % (args.network, modelname, epoch, args.train_proportion)
     checkpoint = torch.load(filename)
-    print "Loading saved embeddings and model: %s" % filename
+    print("Loading saved embeddings and model: %s" % filename)
     args.start_epoch = checkpoint['epoch']
     user_embeddings = Variable(torch.from_numpy(checkpoint['user_embeddings']).cuda())
     item_embeddings = Variable(torch.from_numpy(checkpoint['item_embeddings']).cuda())

--- a/tbatch.py
+++ b/tbatch.py
@@ -28,7 +28,7 @@ num_users = len(user2id)
 num_items = len(item2id) + 1 # one extra item for "none-of-these"
 num_features = len(feature_sequence[0])
 true_labels_ratio = len(y_true)/(1.0+sum(y_true)) # +1 in denominator in case there are no state change labels, which will throw an error. 
-print "*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true))
+print("*** Network statistics:\n  %d users\n  %d items\n  %d interactions\n  %d/%d true labels ***\n\n" % (num_users, num_items, num_interactions, sum(y_true), len(y_true)))
 
 # OUTPUT FILE FOR THE BATCHES
 output_fname = "results/batches_%s.txt" % args.network
@@ -52,7 +52,7 @@ timespan = timestamp_sequence[-1] - timestamp_sequence[0]
 tbatch_timespan = timespan / 500 
 
 # CREATE THE TBATCHES
-print "*** Creating T-batches from %d interactions ***" % train_end_idx
+print("*** Creating T-batches from %d interactions ***" % train_end_idx)
 # INITIALIZE TBATCH PARAMETERS
 tbatch_start_time = None
 tbatch_to_insert = -1
@@ -98,7 +98,7 @@ for j in range(num_interactions):
     # AFTER PROCESSING ALL INTERACTIONS IN A TIMESPAN
     if timestamp - tbatch_start_time > tbatch_timespan or j == num_interactions - 1:
         # AFTER ALL INTERACTIONS IN THE TIME WINDOW ARE CONVERTED TO T-BATCHES, SAVE THEM TO FILE.
-        print 'Read till interaction %d. This timespan had %d interactions and created %d T-batches.' % (j, tbatch_interaction_count, len(lib.current_tbatches_user))
+        print('Read till interaction %d. This timespan had %d interactions and created %d T-batches.' % (j, tbatch_interaction_count, len(lib.current_tbatches_user)))
         total_tbatches_count += len(lib.current_tbatches_user)
         total_interactions_count += tbatch_interaction_count 
 
@@ -127,8 +127,8 @@ for j in range(num_interactions):
         tbatch_to_insert = -1
 
 fout.close()
-print "======================="
-print "T-batching complete. Output file: %s." % output_fname
-print "%d interactions were processed, which created %d t-batches." % (total_interactions_count, total_tbatches_count)
-print "This is a %.3f%% compression." % ((total_interactions_count - total_tbatches_count)*100.0/total_interactions_count)
-print "======================="
+print("=======================")
+print("T-batching complete. Output file: %s." % output_fname)
+print("%d interactions were processed, which created %d t-batches." % (total_interactions_count, total_tbatches_count))
+print("This is a %.3f%% compression." % ((total_interactions_count - total_tbatches_count)*100.0/total_interactions_count))
+print("=======================")


### PR DESCRIPTION
Hi John, I used a dictionary to keep t-batch caches, using the timestamp for starting each training phase as key to make life easier. Some of your code got uncommented(marked with @John in comments).

For better modularization, I'm considering using tbatch.py to preprocess raw data and reuse it jodie.py, as what we need are just batch-id given by tbatch procedure.

Long term goal for improving training/inference scalability and efficacy including gpu related optimization and replacing one-hot vector with other things, it consumed too much memory and disk to save these vectors especially when there's a lot of users/items.